### PR TITLE
this is a testc

### DIFF
--- a/kali.sh
+++ b/kali.sh
@@ -2,90 +2,97 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-#############
-# VARIABLES #
-#############
-base_url="https://cdimage.kali.org"
+create_kali_vm() {
+  local vm_id=$1
+  local cpu_cores=$2
 
-echo "[INFO] 偵測 Kali 最新版 QEMU 映像檔 ..."
-latest_url=$(curl -s "$base_url" | grep -oP 'href="kali-\d+\.\d+/' | sort -V | tail -n 1 | cut -d'"' -f2)
-kali_version="${latest_url//\//}" # e.g. kali-2024.4
-kali_url="${base_url}/${kali_version}/${kali_version}-qemu-amd64.7z"
+  #############
+  # VARIABLES #
+  #############
+  base_url="https://cdimage.kali.org"
 
-working_dir="$(mktemp -d /tmp/kali-download-XXXXXX)"
-trap 'rm -rf "$working_dir"' EXIT
+  echo "[INFO] 偵測 Kali 最新版 QEMU 映像檔 ..."
+  latest_url=$(curl -s "$base_url" | grep -oP 'href="kali-\d+\.\d+/' | sort -V | tail -n 1 | cut -d'"' -f2)
+  kali_version="${latest_url//\//}" # e.g. kali-2024.4
+  kali_url="${base_url}/${kali_version}/${kali_version}-qemu-amd64.7z"
 
-filename="$(basename "$kali_url")"
-vm_id=136
-vm_name="kali-vm"
-vm_description="Kali VM imported from OffSec"
-min_memory=4096
-max_memory=8192
-cpu_cores=4
-os_type="l26"
-storage_target="local-lvm"
-network_bridge="vmbr1"
-vlan_id="666" # Leave empty "" for no VLAN
+  working_dir="$(mktemp -d /tmp/kali-download-XXXXXX)"
+  trap 'rm -rf "$working_dir"' EXIT
 
-################
-# SANITY CHECK #
-################
-echo "[INFO] 檢查 VM ID 是否已被使用 ..."
-if qm status "$vm_id" &>/dev/null; then
-  echo "[ERROR] VM ID $vm_id 已被使用，請選用其他 ID。"
-  exit 1
-fi
+  filename="$(basename "$kali_url")"
+  vm_name="kali-vm"
+  vm_description="Kali VM imported from OffSec"
+  min_memory=4096
+  max_memory=8192
+  os_type="l26"
+  storage_target="local-lvm"
+  network_bridge="vmbr1"
+  vlan_id="666" # Leave empty "" for no VLAN
 
-################
-# DEPENDENCIES #
-################
-echo "[INFO] 安裝必要套件 (unar)..."
-apt-get update -y
-apt-get install -y unar wget curl
+  ################
+  # SANITY CHECK #
+  ################
+  echo "[INFO] 檢查 VM ID 是否已被使用 ..."
+  if qm status "$vm_id" &>/dev/null; then
+    echo "[ERROR] VM ID $vm_id 已被使用，請選用其他 ID。"
+    exit 1
+  fi
 
-#################
-# CREATE THE VM #
-#################
-echo "[INFO] 切換至工作資料夾 $working_dir ..."
-cd "$working_dir"
+  ################
+  # DEPENDENCIES #
+  ################
+  echo "[INFO] 安裝必要套件 (unar)..."
+  apt-get update -y
+  apt-get install -y unar wget curl
 
-echo "[INFO] 下載 Kali QEMU 映像檔：$filename ..."
-wget -c --show-progress "$kali_url"
+  #################
+  # CREATE THE VM #
+  #################
+  echo "[INFO] 切換至工作資料夾 $working_dir ..."
+  cd "$working_dir"
 
-echo "[INFO] 解壓縮映像檔 ..."
-unar "$filename"
+  echo "[INFO] 下載 Kali QEMU 映像檔：$filename ..."
+  wget -c --show-progress "$kali_url"
 
-qcow2file="$(find "$working_dir" -name '*.qcow2' | head -n 1)"
-if [ -z "$qcow2file" ]; then
-  echo "[ERROR] 找不到 .qcow2 磁碟映像，請確認下載檔案是否正確。"
-  exit 1
-fi
+  echo "[INFO] 解壓縮映像檔 ..."
+  unar "$filename"
 
-# 設定網卡
-net_config="model=virtio,firewall=0,bridge=${network_bridge}"
-if [ -n "$vlan_id" ]; then
-  net_config="${net_config},tag=${vlan_id}"
-fi
+  qcow2file="$(find "$working_dir" -name '*.qcow2' | head -n 1)"
+  if [ -z "$qcow2file" ]; then
+    echo "[ERROR] 找不到 .qcow2 磁碟映像，請確認下載檔案是否正確。"
+    exit 1
+  fi
 
-echo "[INFO] 建立 VM ..."
-qm create "$vm_id" \
-  --memory "$max_memory" --balloon "$min_memory" \
-  --cores "$cpu_cores" --name "$vm_name" \
-  --description "$vm_description" --net0 "$net_config" \
-  --ostype "$os_type" --autostart 1 \
-  --startup order=10,up=30,down=30
+  # 設定網卡
+  net_config="model=virtio,firewall=0,bridge=${network_bridge}"
+  if [ -n "$vlan_id" ]; then
+    net_config="${net_config},tag=${vlan_id}"
+  fi
 
-echo "[INFO] 匯入磁碟檔 ..."
-qm importdisk "$vm_id" "$qcow2file" "$storage_target" --format qcow2
+  echo "[INFO] 建立 VM ..."
+  qm create "$vm_id" \
+    --memory "$max_memory" --balloon "$min_memory" \
+    --cores "$cpu_cores" --name "$vm_name" \
+    --description "$vm_description" --net0 "$net_config" \
+    --ostype "$os_type" --autostart 1 \
+    --startup order=10,up=30,down=30
 
-echo "[INFO] 掛載磁碟至 VM ..."
-qm set "$vm_id" --scsi0 "${storage_target}:vm-${vm_id}-disk-0"
+  echo "[INFO] 匯入磁碟檔 ..."
+  qm importdisk "$vm_id" "$qcow2file" "$storage_target" --format qcow2
 
-echo "[INFO] 設定開機磁碟 ..."
-qm set "$vm_id" --boot order=scsi0
+  echo "[INFO] 掛載磁碟至 VM ..."
+  qm set "$vm_id" --scsi0 "${storage_target}:vm-${vm_id}-disk-0"
 
-echo "[INFO] 啟動 VM ..."
-qm start "$vm_id"
+  echo "[INFO] 設定開機磁碟 ..."
+  qm set "$vm_id" --boot order=scsi0
 
-echo "[SUCCESS] Kali VM (${kali_version}) 建立完成並已啟動。"
+  echo "[INFO] 啟動 VM ..."
+  qm start "$vm_id"
+
+  echo "[SUCCESS] Kali VM (${kali_version}) 建立完成並已啟動。"
+}
+
+# Example usage
+# create_kali_vm <vm_id> <cpu_cores>
+create_kali_vm 136 4
 

--- a/test_kali.sh
+++ b/test_kali.sh
@@ -157,3 +157,46 @@ echo " Kali VM 建立與啟動完成！"
 echo " 儲存資料夾：$working_dir"
 echo " 擴充磁碟：$disk_expand_size"
 echo "  VM ID：$vm_id"
+
+# Unit test for create_kali_vm function
+
+test_create_kali_vm() {
+  echo "[TEST] Testing create_kali_vm function..."
+
+  # Test parameters
+  local test_vm_id=999
+  local test_cpu_cores=2
+
+  # Mock qm command to avoid actual VM creation
+  qm() {
+    echo "[MOCK] qm $@"
+  }
+
+  # Mock apt-get to avoid actual package installation
+  apt-get() {
+    echo "[MOCK] apt-get $@"
+  }
+
+  # Mock wget to avoid actual file download
+  wget() {
+    echo "[MOCK] wget $@"
+  }
+
+  # Mock unar to avoid actual file extraction
+  unar() {
+    echo "[MOCK] unar $@"
+  }
+
+  # Mock curl to return a fake latest URL
+  curl() {
+    echo "href=\"kali-2025.1/\""
+  }
+
+  # Run the function
+  create_kali_vm "$test_vm_id" "$test_cpu_cores"
+
+  echo "[TEST] create_kali_vm test completed."
+}
+
+# Run the test
+test_create_kali_vm


### PR DESCRIPTION
This pull request refactors the `kali.sh` script by introducing a reusable function for creating a Kali VM and adds a unit test for this function in `test_kali.sh`. The changes improve modularity and testability of the script.

### Refactoring and modularization:
* Introduced a new `create_kali_vm` function in `kali.sh` to encapsulate the VM creation logic. It accepts `vm_id` and `cpu_cores` as parameters, replacing hardcoded values. [[1]](diffhunk://#diff-881a491c675984855f82dd5ad1db42339f3a27ffbc31c08924ab49ddcac2779eR5-R8) [[2]](diffhunk://#diff-881a491c675984855f82dd5ad1db42339f3a27ffbc31c08924ab49ddcac2779eL19-L24) [[3]](diffhunk://#diff-881a491c675984855f82dd5ad1db42339f3a27ffbc31c08924ab49ddcac2779eR93-R97)

### Testing enhancements:
* Added a unit test for the `create_kali_vm` function in `test_kali.sh`. The test uses mocked commands (`qm`, `apt-get`, `wget`, `unar`, and `curl`) to simulate the VM creation process without making actual changes to the system.ycccc